### PR TITLE
Remove NFT contract address from the target object

### DIFF
--- a/transaction-react/src/App.tsx
+++ b/transaction-react/src/App.tsx
@@ -6,6 +6,7 @@ import {useProvider} from '@rarimo/react-provider'
 import {MetamaskProvider} from '@rarimo/provider'
 import {useEffect, useMemo} from "react";
 
+// Address of the NFT sale contract
 const NFT_CONTRACT_ADDRESS = "0x77fedfb705c8bac2e03aad2ad8a8fe83e3e20fa1"
 
 const App = () => {
@@ -28,8 +29,6 @@ const App = () => {
    return {
      // Source chain id (Sepolia in this case)
      chainId: 11155111,
-     // NFT contract address
-     address: NFT_CONTRACT_ADDRESS,
      // Recipient wallet address
      recipient: provider?.address ?? '',
      price: priceOfNft,


### PR DESCRIPTION
We no longer use the NFT contract address in the target object; it's in the bundle.